### PR TITLE
Mount host /tmp in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,8 @@
     "features": {
       "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
         "./src/devcontainer": {}
-    }
+    },
+    "mounts": [
+      "source=/tmp/,target=/tmp/,type=bind"
+    ]
 }


### PR DESCRIPTION
`devcontainer features tests` uses /tmp, so it must be shared w/ the host Docker daemon